### PR TITLE
Explicitly require pathname class

### DIFF
--- a/app/config.rb
+++ b/app/config.rb
@@ -1,3 +1,5 @@
+require 'pathname'
+
 class Config
   def initialize(environment)
     @environment = environment || "development"


### PR DESCRIPTION
The `Pathname` class needs to be explicitly required in the app config, it seems to only be a problem
on AWS infrastructure.

```
irb(main):001:0> class Foo; Pathname.new("/foo"); end
NameError: uninitialized constant Foo::Pathname
	from (irb):1:in `<class:Foo>'
	from (irb):1
	from /usr/bin/irb:12:in `<main>'
irb(main):002:0> require 'pathname'; class Foo; Pathname.new("/foo"); end
=> #<Pathname:/foo>
```