### PR TITLE
Cache node requests for 5 minutes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "govuk_message_queue_consumer", "~> 3.2"
 gem "rake", "~> 12.3"
 
 group :development, :test do
+  gem "byebug"
   gem "govuk-lint", "~> 3.9"
   gem "govuk_test", "~> 0.2"
   gem "rspec-core", "~> 3.8"
@@ -15,5 +16,6 @@ end
 
 group :test do
   gem "climate_control"
+  gem "timecop"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,7 @@ GEM
     aws-sigv4 (1.0.3)
     bunny (2.11.0)
       amq-protocol (~> 2.3.0)
+    byebug (10.0.2)
     capybara (3.7.1)
       addressable
       mini_mime (>= 0.1.3)
@@ -133,6 +134,7 @@ GEM
       faraday (>= 0.7.6, < 1.0)
     statsd-ruby (1.4.0)
     thread_safe (0.3.6)
+    timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.4.0)
@@ -151,6 +153,7 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk-ec2 (~> 1)
+  byebug
   climate_control
   govuk-lint (~> 3.9)
   govuk_app_config (~> 1.8)
@@ -160,6 +163,7 @@ DEPENDENCIES
   rspec-core (~> 3.8)
   rspec-expectations (~> 3.8)
   rspec-mocks (~> 3.8)
+  timecop
   webmock
 
 BUNDLED WITH

--- a/lib/govuk_nodes.rb
+++ b/lib/govuk_nodes.rb
@@ -2,8 +2,34 @@ require_relative "govuk_nodes/aws_fetcher"
 require_relative "govuk_nodes/carrenza_fetcher"
 
 class GovukNodes
+  CACHE_TIME = (60 * 5) # 5 minutes
+
   def self.of_class(node_class)
-    self.new.of_class(node_class)
+    if (cached_nodes = cached_nodes_for_class(node_class))
+      cached_nodes
+    else
+      nodes = self.new.of_class(node_class)
+      cache(nodes, node_class)
+      nodes
+    end
+  end
+
+  def self.cached_nodes_for_class(node_class)
+    return unless @cached_nodes&.has_key?(node_class)
+
+    (nodes, cached_at) = @cached_nodes.fetch(node_class)
+    still_fresh = (Time.now.to_i - cached_at) < CACHE_TIME
+
+    return nodes if still_fresh
+  end
+
+  def self.cache(nodes, node_class)
+    @cached_nodes ||= {}
+    @cached_nodes[node_class] = [nodes, Time.now.to_i]
+  end
+
+  def self.clear_cache
+    @cached_nodes = {}
   end
 
   def of_class(node_class)

--- a/spec/govuk_nodes_spec.rb
+++ b/spec/govuk_nodes_spec.rb
@@ -19,11 +19,31 @@ RSpec.describe GovukNodes do
       ]
     }
 
-    it "uses the AWS fetcher" do
-      expect_any_instance_of(described_class::AWSFetcher).to receive(:hostnames_of_class)
-        .with(node_class).and_return(fetcher_response)
+    let(:aws_fetcher) { double(:aws_fetcher) }
 
+    before do
+      allow(described_class::AWSFetcher).to receive(:new).and_return(aws_fetcher)
+      allow(aws_fetcher).to receive(:hostnames_of_class).with(node_class)
+        .and_return(fetcher_response)
+    end
+
+    it "uses the AWS fetcher" do
       expect(described_class.of_class(node_class)).to eq(fetcher_response)
+    end
+
+    it "caches node request calls for 5 minutes" do
+      described_class.of_class(node_class)
+      expect(aws_fetcher).to have_received(:hostnames_of_class).once
+
+      Timecop.freeze(Time.now + (60 * 4))
+
+      described_class.of_class(node_class)
+      expect(aws_fetcher).to have_received(:hostnames_of_class).once
+
+      Timecop.freeze(Time.now + (60 * 2))
+
+      described_class.of_class(node_class)
+      expect(aws_fetcher).to have_received(:hostnames_of_class).twice
     end
   end
 
@@ -34,11 +54,31 @@ RSpec.describe GovukNodes do
       ]
     }
 
-    it "uses the Carrenza fetcher" do
-      expect_any_instance_of(described_class::CarrenzaFetcher).to receive(:hostnames_of_class)
-        .with(node_class).and_return(fetcher_response)
+    let(:carrenza_fetcher) { double(:carrenza_fetcher) }
 
+    before do
+      allow(described_class::CarrenzaFetcher).to receive(:new).and_return(carrenza_fetcher)
+      allow(carrenza_fetcher).to receive(:hostnames_of_class).with(node_class)
+        .and_return(fetcher_response)
+    end
+
+    it "uses the Carrenza fetcher" do
       expect(described_class.of_class(node_class)).to eq(fetcher_response)
+    end
+
+    it "caches node request calls for 5 minutes" do
+      described_class.of_class(node_class)
+      expect(carrenza_fetcher).to have_received(:hostnames_of_class).once
+
+      Timecop.freeze(Time.now + (60 * 4))
+
+      described_class.of_class(node_class)
+      expect(carrenza_fetcher).to have_received(:hostnames_of_class).once
+
+      Timecop.freeze(Time.now + (60 * 2))
+
+      described_class.of_class(node_class)
+      expect(carrenza_fetcher).to have_received(:hostnames_of_class).twice
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -92,4 +92,13 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+
+  config.before(:example) do
+    Timecop.freeze(Time.local(1994))
+  end
+
+  config.after(:example) do
+    Timecop.freeze(Time.local(1994))
+    GovukNodes.clear_cache
+  end
 end


### PR DESCRIPTION
We're hitting AWS (and perhaps other) request limits with this, so let's cache it.

If we need to put more effort in later we could convert this to exponential backoff using the "too many requests" exception we get from the AWS client.

https://trello.com/c/f8U7EfUh/427-make-the-new-cache-clearing-app-invalidate-cache-in-varnish