### PR TITLE
We really mean it when we say don't escape these characters

### DIFF
--- a/lib/govuk_nodes/carrenza_fetcher.rb
+++ b/lib/govuk_nodes/carrenza_fetcher.rb
@@ -18,7 +18,7 @@ class GovukNodes
 
     def query_string(node_class)
       hyphenated_node_class = node_class.tr("_", "-")
-      query = %{["or", ["~", ["fact", "fqdn"], "^#{hyphenated_node_class}-\\d+."]]}
+      query = %{["or", ["~", ["fact", "fqdn"], "^#{hyphenated_node_class}-\\\\d+\\\\."]]}
 
       URI.encode_www_form(query: query)
     end

--- a/spec/support/puppetdb_helper.rb
+++ b/spec/support/puppetdb_helper.rb
@@ -13,7 +13,7 @@ module PuppetDBHelper
   end
 
   def db_url(base_url, node_class)
-    query = '["or", ["~", ["fact", "fqdn"], "^' + node_class + '-\d+."]]'
+    query = '["or", ["~", ["fact", "fqdn"], "^' + node_class + '-\\\d+\\\."]]'
     query_string = URI.encode_www_form(query: query)
     "#{base_url}?#{query_string}"
   end


### PR DESCRIPTION
This is required to wind up with a string like the following encoded in the URL:
`["or", ["~", ["fact", "fqdn"], "^cache-\\d+\\."]]`

https://trello.com/c/f8U7EfUh/427-make-the-new-cache-clearing-app-invalidate-cache-in-varnish