### PR TITLE
Add headers to puppet request

### DIFF
--- a/lib/govuk_nodes/carrenza_fetcher.rb
+++ b/lib/govuk_nodes/carrenza_fetcher.rb
@@ -12,7 +12,12 @@ class GovukNodes
 
     def instances_of_class(node_class)
       url = "#{puppetdb_node_url}?#{query_string(node_class)}"
-      json_response = URI.open(url).read
+      headers = {
+        "Accept" => "application/json",
+        "User-Agent" => "cache-clearing-service",
+      }
+
+      json_response = URI.open(url, headers).read
       JSON.parse(json_response)
     end
 


### PR DESCRIPTION
- `Accept` header to allow the return of JSON
- `User-Agent` so we know what app is making the requests

https://trello.com/c/f8U7EfUh/427-make-the-new-cache-clearing-app-invalidate-cache-in-varnish

I have tested this on staging, and the code does work, but it's being bafflingly inconsistent which for now I'm going to chalk up to processes not fully restarting, but we'll have to keep an eye on it