### PR TITLE
Clear the cache for routes and redirects

### DIFF
--- a/spec/processor_spec.rb
+++ b/spec/processor_spec.rb
@@ -1,6 +1,4 @@
 RSpec.describe Processor do
-  let(:base_path) { "/government/news/govuk-implements-new-cache-clearing" }
-  let(:payload) { { "base_path" => base_path } }
   let(:message) { double(ack: nil, payload: payload) }
 
   before do
@@ -8,18 +6,87 @@ RSpec.describe Processor do
     allow_any_instance_of(FastlyClearer).to receive(:clear_for)
   end
 
-  it "clears the varnish cache for the base path" do
-    expect_any_instance_of(VarnishClearer).to receive(:clear_for).with(base_path)
-    subject.process(message)
+  shared_examples "acks messages" do
+    it "acks messages" do
+      subject.process(message)
+      expect(message).to have_received(:ack)
+    end
   end
 
-  it "clears the Fastly cache for the base path" do
-    expect_any_instance_of(FastlyClearer).to receive(:clear_for).with(base_path)
-    subject.process(message)
+  shared_examples "doesn't clear the cache" do
+    it "doesn't clear the Varnish cache" do
+      expect_any_instance_of(VarnishClearer).not_to receive(:clear_for)
+      subject.process(message)
+    end
+
+    it "doesn't clear the Fastly cache" do
+      expect_any_instance_of(FastlyClearer).not_to receive(:clear_for)
+      subject.process(message)
+    end
   end
 
-  it "acks messages" do
-    subject.process(message)
-    expect(message).to have_received(:ack)
+  shared_examples "clears the cache" do |path|
+    it "clears the varnish cache for #{path}" do
+      expect_any_instance_of(VarnishClearer).to receive(:clear_for).with(path)
+      subject.process(message)
+    end
+
+    it "clears the Fastly cache for #{path}" do
+      expect_any_instance_of(FastlyClearer).to receive(:clear_for).with(path)
+      subject.process(message)
+    end
+  end
+
+  context "when the route is exact" do
+    let(:payload) do
+      {
+        "routes" => [{ "path" => "/government/news/govuk-implements-new-cache-clearing", "type" => "exact" }],
+      }
+    end
+
+    include_examples "acks messages"
+    include_examples "clears the cache", "/government/news/govuk-implements-new-cache-clearing"
+  end
+
+  context "when the redirect is exact" do
+    let(:payload) do
+      {
+        "redirects" => [{ "path" => "/government/news/govuk-implements-new-cache-clearing", "type" => "exact" }],
+      }
+    end
+
+    include_examples "acks messages"
+    include_examples "clears the cache", "/government/news/govuk-implements-new-cache-clearing"
+  end
+
+  context "when the route is a prefix" do
+    let(:payload) do
+      { "routes" => [{ "path" => "/government", "type" => "prefix" }] }
+    end
+
+    include_examples "acks messages"
+    include_examples "doesn't clear the cache"
+  end
+
+  context "when the redirect is a prefix" do
+    let(:payload) do
+      { "redirects" => [{ "path" => "/government", "type" => "prefix" }] }
+    end
+
+    include_examples "acks messages"
+    include_examples "doesn't clear the cache"
+  end
+
+  context "when the content has no routes or redirects" do
+    let(:payload) do
+      {
+        "base_path" => "/test",
+        "routes" => [],
+        "redirects" => [],
+      }
+    end
+
+    include_examples "acks messages"
+    include_examples "doesn't clear the cache"
   end
 end


### PR DESCRIPTION
Some content items may be accessible from multiple routes, therefore just clearing the `base_path` is not sufficient.

[Trello Card](https://trello.com/c/9k1peA1F/434-make-the-new-cache-clearing-app-invalidate-cache-in-fastly)