### PR TITLE
Log error messages when processing queue

### DIFF
--- a/app/processor.rb
+++ b/app/processor.rb
@@ -2,6 +2,8 @@ require "net/http"
 require "lib/govuk_nodes"
 
 class Processor
+  attr_reader :logger
+
   def initialize
     @logger = CacheClearingService.config.logger
     @varnish_clearer = VarnishClearer.new(logger)
@@ -9,9 +11,13 @@ class Processor
   end
 
   def process(message)
-    paths_for(content_item: message.payload).each do |path|
-      varnish_clearer.clear_for(path)
-      fastly_clearer.clear_for(path)
+    begin
+      paths_for(content_item: message.payload).each do |path|
+        varnish_clearer.clear_for(path)
+        fastly_clearer.clear_for(path)
+      end
+    rescue StandardError => e
+      logger.error(e)
     end
 
     message.ack
@@ -28,5 +34,5 @@ class Processor
 
 private
 
-  attr_reader :fastly_clearer, :logger, :varnish_clearer
+  attr_reader :fastly_clearer, :varnish_clearer
 end

--- a/app/processor.rb
+++ b/app/processor.rb
@@ -18,6 +18,7 @@ class Processor
       end
     rescue StandardError => e
       logger.error(e)
+      GovukError.notify(e)
     end
 
     message.ack

--- a/spec/processor_spec.rb
+++ b/spec/processor_spec.rb
@@ -89,4 +89,21 @@ RSpec.describe Processor do
     include_examples "acks messages"
     include_examples "doesn't clear the cache"
   end
+
+  context "when an error is raised" do
+    let(:payload) do
+      { "routes" => [{ "path" => "/error-cache-clearing", "type" => "exact" }] }
+    end
+    let(:error) { FastlyClearer::FastlyCacheClearFailed.new("Non") }
+
+    before do
+      allow_any_instance_of(FastlyClearer).to receive(:clear_for)
+        .and_raise(error)
+    end
+
+    it "logs the error" do
+      expect(subject.logger).to receive(:error).with(error)
+      subject.process(message)
+    end
+  end
 end

--- a/spec/processor_spec.rb
+++ b/spec/processor_spec.rb
@@ -103,6 +103,7 @@ RSpec.describe Processor do
 
     it "logs the error" do
       expect(subject.logger).to receive(:error).with(error)
+      expect(GovukError).to receive(:notify).with(error)
       subject.process(message)
     end
   end


### PR DESCRIPTION
Errors were being raised which we suspect eventually killed the systemd service as the logs only contained entries coming from the clearer classes . 
```
# If the app respawns more than 5 times in 20 seconds, it has deeper problems
# and should be killed off.
respawn limit 5 20
```
Handling and logging them in the Processor class will help keep the service up.
I tested the theory on one of the integration backends where the problem was present, the service stayed up with the logging in place.
Also notifies `GovukError` of the issue so that it reaches Sentry.