### PR TITLE
Make sure base_path is passed to the other tasks

### DIFF
--- a/lib/tasks/cache.rake
+++ b/lib/tasks/cache.rake
@@ -12,5 +12,5 @@ namespace :cache do
   end
 
   desc "Clear cache for a given base path"
-  task clear: %i(clear_varnish clear_fastly)
+  task :clear, [:base_path] => %i(clear_varnish clear_fastly)
 end


### PR DESCRIPTION
This was not working before as the arguments don't get passed automatically.