### PR TITLE
Don't bundle exec running the app in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Varnish for that path.
 ### Running the application
 
 ```sh
-$ bundle exec bin/cache_clearing_service
+$ bin/cache_clearing_service
 ```
 
 ### Running the test suite


### PR DESCRIPTION
You don't need to run `bundle exec` because the `bin/cache_clearing_service` file does that already for you.