### PR TITLE
Report errors individually

### DIFF
--- a/app/processor.rb
+++ b/app/processor.rb
@@ -11,11 +11,9 @@ class Processor
   end
 
   def process(message)
-    begin
-      paths_for(content_item: message.payload).each do |path|
-        varnish_clearer.clear_for(path)
-        fastly_clearer.clear_for(path)
-      end
+    paths_for(content_item: message.payload).each do |path|
+      varnish_clearer.clear_for(path)
+      fastly_clearer.clear_for(path)
     rescue StandardError => e
       logger.error(e)
       GovukError.notify(e)

--- a/spec/processor_spec.rb
+++ b/spec/processor_spec.rb
@@ -118,8 +118,8 @@ RSpec.describe Processor do
     end
 
     it "logs the error" do
-      expect(subject.logger).to receive(:error).with(error)
-      expect(GovukError).to receive(:notify).with(error)
+      expect(subject.logger).to receive(:error).with(error).twice
+      expect(GovukError).to receive(:notify).with(error).twice
       subject.process(message)
     end
   end


### PR DESCRIPTION
This prevents the other routes from not being cleared if one route earlier on in the list fails.