### PR TITLE
Purge pages softly

### DIFF
--- a/app/services/purger.rb
+++ b/app/services/purger.rb
@@ -25,6 +25,11 @@ private
     METHOD = "PURGE".freeze
     REQUEST_HAS_BODY = false
     RESPONSE_HAS_BODY = true
+
+    def initialize(*args)
+      super(*args)
+      self["Fastly-Soft-Purge"] = "1"
+    end
   end
 
   class PurgeFailed < StandardError; end

--- a/spec/purger_spec.rb
+++ b/spec/purger_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Purger do
   context "if the purge request succeeds" do
     before do
       stub_request(:purge, /cache/)
+        .with(headers: { "Fastly-Soft-Purge": "1" })
     end
 
     it "purges the cache for the base path in the payload" do
@@ -16,7 +17,9 @@ RSpec.describe Purger do
 
   context "if the purge request fails" do
     before do
-      stub_request(:purge, /cache/).to_return(status: 500)
+      stub_request(:purge, /cache/)
+        .with(headers: { "Fastly-Soft-Purge": "1" })
+        .to_return(status: 500)
     end
 
     it "raises an error" do


### PR DESCRIPTION
Fastly has the concept of a soft purge that sets the TTL of a page to 0, but doesn't actually remove the page from its cache. This means that if the frontend is down for whatever reason, it'll still be able to serve content from its caches.

https://docs.fastly.com/api/purge#soft_purge