### PR TITLE
Change ./bin/cache_clearing_service to exec bundler

### DIFF
--- a/bin/cache_clearing_service
+++ b/bin/cache_clearing_service
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
-bundle exec rake message_queue:consumer
+
+exec bundle exec rake message_queue:consumer


### PR DESCRIPTION
Rather than running it as a child process. This is neater, and I'm
hoping it will help upstart manage this service better. Currently, I
think there are old rake processes left around when it's restarted.