### PR TITLE
Clear paths in parallel using threads

### DIFF
--- a/app/processor.rb
+++ b/app/processor.rb
@@ -12,16 +12,20 @@ class Processor
 
   def process(message)
     paths_for(content_item: message.payload).each do |path|
-      GovukStatsd.time("purge.all") do
-        varnish_clearer.clear_for(path)
-        fastly_clearer.clear_for(path)
-      end
-    rescue StandardError => e
-      logger.error(e)
-      GovukError.notify(e)
+      purge_path(path)
     end
 
     message.ack
+  end
+
+  def purge_path(path)
+    GovukStatsd.time("purge.all") do
+      varnish_clearer.clear_for(path)
+      fastly_clearer.clear_for(path)
+    end
+  rescue StandardError => e
+    logger.error(e)
+    GovukError.notify(e)
   end
 
   def paths_for(content_item:)

--- a/app/processor.rb
+++ b/app/processor.rb
@@ -11,9 +11,11 @@ class Processor
   end
 
   def process(message)
-    paths_for(content_item: message.payload).each do |path|
-      purge_path(path)
+    threads = paths_for(content_item: message.payload).map do |path|
+      Thread.new { purge_path(path) }
     end
+
+    threads.each(&:join)
 
     message.ack
   end


### PR DESCRIPTION
Rather than purging each path one by one this spawns a thread for each path and runs it in parallel.

At the moment the process doesn't happen quick enough and the queue can back up.

In theory, this should improve processing speed by a factor of 2 on average (since a content item has at least two paths, its own base path and the `/api/content` variation) but we'll deploy it to see whether this improves the situation and if not look into further optimisations.

A potential for the future might be to look into more advances methods such as using [Typhoeus](https://github.com/typhoeus/typhoeus) to execute all the `PURGE` requests in parallel.