### PR TITLE
Only purge pages that were updated recently

### DIFF
--- a/spec/govuk_nodes_spec.rb
+++ b/spec/govuk_nodes_spec.rb
@@ -6,6 +6,15 @@ RSpec.describe GovukNodes do
   let(:node_class) { "email_alert_api" }
   let(:stack_name) { "green" }
 
+  before(:example) do
+    Timecop.freeze(Time.local(1994))
+  end
+
+  after(:example) do
+    Timecop.freeze(Time.local(1994))
+    GovukNodes.clear_cache
+  end
+
   context "if the AWS flag is on" do
     around do |example|
       ClimateControl.modify AWS_STACKNAME: stack_name do

--- a/spec/processor_spec.rb
+++ b/spec/processor_spec.rb
@@ -123,4 +123,40 @@ RSpec.describe Processor do
       subject.process(message)
     end
   end
+
+  context "when the page was updated over an hour ago" do
+    around(:each) do |example|
+      Timecop.freeze(Time.new(2018, 1, 1, 10)) { example.run }
+    end
+
+    let(:payload) do
+      {
+        "base_path" => "/old-page",
+        "routes" => [{ "path" => "/old-page", "type" => "exact" }],
+        "updated_at" => "2018-01-01T08:00:00Z",
+      }
+    end
+
+    include_examples "acks messages"
+    include_examples "doesn't clear the cache", "/old-page"
+    include_examples "doesn't clear the cache", "/api/content/old-page"
+  end
+
+  context "when the page was updated less than an hour ago" do
+    around(:each) do |example|
+      Timecop.freeze(Time.new(2018, 1, 1, 10)) { example.run }
+    end
+
+    let(:payload) do
+      {
+        "base_path" => "/old-page",
+        "routes" => [{ "path" => "/old-page", "type" => "exact" }],
+        "updated_at" => "2018-01-01T09:30:00Z",
+      }
+    end
+
+    include_examples "acks messages"
+    include_examples "clears the cache", "/old-page"
+    include_examples "clears the cache", "/api/content/old-page"
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -92,13 +92,4 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
-
-  config.before(:example) do
-    Timecop.freeze(Time.local(1994))
-  end
-
-  config.after(:example) do
-    Timecop.freeze(Time.local(1994))
-    GovukNodes.clear_cache
-  end
 end


### PR DESCRIPTION
We're seeing the queue for cache-clearing-service back up quite significantly. Although we should fix this problem, it's worth adding code into cache-clearing-service to not bother clearing the cache of pages that were updated over an hour ago and therefore likely already have their cache cleared. This should prevent the backlog from growing excessively big.