### PR TITLE
Revert "Only purge pages that were updated recently"

### DIFF
--- a/spec/govuk_nodes_spec.rb
+++ b/spec/govuk_nodes_spec.rb
@@ -6,15 +6,6 @@ RSpec.describe GovukNodes do
   let(:node_class) { "email_alert_api" }
   let(:stack_name) { "green" }
 
-  before(:example) do
-    Timecop.freeze(Time.local(1994))
-  end
-
-  after(:example) do
-    Timecop.freeze(Time.local(1994))
-    GovukNodes.clear_cache
-  end
-
   context "if the AWS flag is on" do
     around do |example|
       ClimateControl.modify AWS_STACKNAME: stack_name do

--- a/spec/processor_spec.rb
+++ b/spec/processor_spec.rb
@@ -123,40 +123,4 @@ RSpec.describe Processor do
       subject.process(message)
     end
   end
-
-  context "when the page was updated over an hour ago" do
-    around(:each) do |example|
-      Timecop.freeze(Time.new(2018, 1, 1, 10)) { example.run }
-    end
-
-    let(:payload) do
-      {
-        "base_path" => "/old-page",
-        "routes" => [{ "path" => "/old-page", "type" => "exact" }],
-        "updated_at" => "2018-01-01T08:00:00Z",
-      }
-    end
-
-    include_examples "acks messages"
-    include_examples "doesn't clear the cache", "/old-page"
-    include_examples "doesn't clear the cache", "/api/content/old-page"
-  end
-
-  context "when the page was updated less than an hour ago" do
-    around(:each) do |example|
-      Timecop.freeze(Time.new(2018, 1, 1, 10)) { example.run }
-    end
-
-    let(:payload) do
-      {
-        "base_path" => "/old-page",
-        "routes" => [{ "path" => "/old-page", "type" => "exact" }],
-        "updated_at" => "2018-01-01T09:30:00Z",
-      }
-    end
-
-    include_examples "acks messages"
-    include_examples "clears the cache", "/old-page"
-    include_examples "clears the cache", "/api/content/old-page"
-  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -92,4 +92,13 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+
+  config.before(:example) do
+    Timecop.freeze(Time.local(1994))
+  end
+
+  config.after(:example) do
+    Timecop.freeze(Time.local(1994))
+    GovukNodes.clear_cache
+  end
 end


### PR DESCRIPTION
Reverts alphagov/cache-clearing-service#75

Turns out we can't do this because the `updated_at` time isn't passed into the payload.