### PR TITLE
Reduce the number of low cache-clearing-service workers

### DIFF
--- a/.foreman
+++ b/.foreman
@@ -1,1 +1,1 @@
-formation: high=2,medium=2,low=7
+formation: high=2,medium=2,low=3


### PR DESCRIPTION
From 7 to 3, as the load placed on Varnish from the Cache Clearing
Service is causing issues with processing normal requests.