### PR TITLE
Allow Fastly cache clearing for full URLs

### DIFF
--- a/app/services/fastly_clearer.rb
+++ b/app/services/fastly_clearer.rb
@@ -4,9 +4,9 @@ class FastlyClearer
     @purger = Purger.new(logger)
   end
 
-  def clear_for(base_path)
+  def clear_for(base_path_or_url)
     GovukStatsd.time("purge.fastly") do
-      purger.purge("#{website_root}#{base_path}")
+      purger.purge(full_url(base_path_or_url))
     end
   rescue Purger::PurgeFailed => e
     raise FastlyCacheClearFailed, e
@@ -18,6 +18,14 @@ private
 
   def website_root
     @website_root ||= Plek.new.website_root
+  end
+
+  def full_url(base_path_or_url)
+    if base_path_or_url.start_with?("http")
+      base_path_or_url
+    else
+      "#{website_root}#{base_path_or_url}"
+    end
   end
 
   class FastlyCacheClearFailed < StandardError; end

--- a/lib/tasks/cache.rake
+++ b/lib/tasks/cache.rake
@@ -5,10 +5,10 @@ namespace :cache do
     clearer.clear_for(args[:base_path])
   end
 
-  desc "Clear Fastly cache for a given base path"
-  task :clear_fastly, [:base_path] do |_, args|
+  desc "Clear Fastly cache for a given base path or URL"
+  task :clear_fastly, [:base_path_or_url] do |_, args|
     clearer = FastlyClearer.new(Logger.new(STDOUT))
-    clearer.clear_for(args[:base_path])
+    clearer.clear_for(args[:base_path_or_url])
   end
 
   desc "Clear cache for a given base path"

--- a/spec/fastly_clearer_spec.rb
+++ b/spec/fastly_clearer_spec.rb
@@ -21,4 +21,12 @@ RSpec.describe FastlyClearer do
       }.to raise_error(FastlyClearer::FastlyCacheClearFailed)
     end
   end
+
+  context "if a full URL is provided" do
+    it "clears the full URL rather than prepending the website root" do
+      url = "https://assets.example.gov.uk#{base_path}"
+      expect_any_instance_of(Purger).to receive(:purge).with(url)
+      subject.clear_for(url)
+    end
+  end
 end


### PR DESCRIPTION
When clearing assets we need to use a different hostname for clearing Fastly cache, so this allows a full URL to be provided for Fastly only.

This is not supported in the Varnish or Fastly & Varnish tasks because assets do not go through Varnish.

https://trello.com/c/RASJllyU/916-update-hmrc-paye-tools-cache-clearing-documentation