### PR TITLE
Log issues with nil paths

### DIFF
--- a/app/processor.rb
+++ b/app/processor.rb
@@ -13,6 +13,12 @@ class Processor
 
   def process(message)
     threads = paths_for(content_item: message.payload).map do |path|
+      if path.nil?
+        logger.error("nil path from payload: #{message.payload}")
+
+        next
+      end
+
       Thread.new(path) { |p| purge_path(p) }
     end
 


### PR DESCRIPTION
We're currently getting errors with nil paths. I'm not sure where
these nil paths are coming from, so avoid erroring by skipping the
path if it's nil, and also log the payload so we can investigate
further.