### PR TITLE
Don't report errors to Sentry from cache:* Rake tasks

### DIFF
--- a/lib/tasks/cache.rake
+++ b/lib/tasks/cache.rake
@@ -3,12 +3,16 @@ namespace :cache do
   task :clear_varnish, [:base_path] do |_, args|
     clearer = VarnishClearer.new(Logger.new(STDOUT))
     clearer.clear_for(args[:base_path])
+  rescue StandardError => e
+    puts "clear_varnish: error: #{e}"
   end
 
   desc "Clear Fastly cache for a given base path or URL"
   task :clear_fastly, [:base_path_or_url] do |_, args|
     clearer = FastlyClearer.new(Logger.new(STDOUT))
     clearer.clear_for(args[:base_path_or_url])
+  rescue StandardError => e
+    puts "clear_fastly: error: #{e}"
   end
 
   desc "Clear cache for a given base path"


### PR DESCRIPTION
These tasks are run manually, so just print the error out, as it's
often a invalid path.