### PR TITLE
Fix rake task dependencies

### DIFF
--- a/lib/tasks/cache.rake
+++ b/lib/tasks/cache.rake
@@ -16,5 +16,8 @@ namespace :cache do
   end
 
   desc "Clear cache for a given base path"
-  task :clear, [:base_path] => %i(clear_varnish clear_fastly)
+  task :clear, [:base_path] do |_, args|
+    Rake::Task["cache:clear_varnish"].invoke(args[:base_path])
+    Rake::Task["cache:clear_fastly"].invoke(args[:base_path])
+  end
 end


### PR DESCRIPTION
The `cache:clear_fastly` rake task has a param named `:base_path_or_url`.  The arg that is passed on from the `cache:clear` task when both the varnish and fastly caches are to be cleared is called `:base_path`.

This means that the fastly task doesn't work at the moment when called as a dependency and fails with the [following error](https://deploy.blue.production.govuk.digital/job/run-rake-task/19810/console):

> clear_fastly: error: undefined method `start_with?' for nil:NilClass

I've changed the `cache:clear` task to invoke both subtasks directly. I considered changing the parameter name of the fastly task back to `:base_path`, but it's useful to be aware that you can pass a full URL into this task (as when clearing assets for example).