### PR TITLE
Replace govuk-lint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,6 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+
 Rails:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -9,12 +9,12 @@ gem "rake", "~> 13.0"
 
 group :development, :test do
   gem "byebug"
-  gem "govuk-lint", "~> 4.3"
   gem "govuk_test", "~> 1.0"
   gem "pry", "~> 0.12"
   gem "rspec-core", "~> 3.9"
   gem "rspec-expectations", "~> 3.9"
   gem "rspec-mocks", "~> 3.9"
+  gem "rubocop-govuk"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,13 +44,7 @@ GEM
     diff-lcs (1.3)
     faraday (0.17.0)
       multipart-post (>= 1.2, < 3)
-    ffi (1.11.2)
     foreman (0.86.0)
-    govuk-lint (4.3.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_app_config (2.0.1)
       logstasher (>= 1.2.2, < 1.4.0)
       sentry-raven (>= 2.7.1, < 2.12.0)
@@ -99,9 +93,6 @@ GEM
     rainbow (3.0.0)
     raindrops (0.19.0)
     rake (13.0.0)
-    rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
-      ffi (~> 1.0)
     regexp_parser (1.6.0)
     request_store (1.4.1)
       rack (>= 1.4)
@@ -121,6 +112,10 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-govuk (1.0.0)
+      rubocop (~> 0.76)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
     rubocop-rails (2.3.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
@@ -129,13 +124,6 @@ GEM
     ruby-progressbar (1.10.1)
     rubyzip (2.0.0)
     safe_yaml (1.0.5)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
     selenium-webdriver (3.142.6)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -170,7 +158,6 @@ DEPENDENCIES
   byebug
   climate_control
   foreman
-  govuk-lint (~> 4.3)
   govuk_app_config (~> 2.0)
   govuk_message_queue_consumer (~> 3.5)
   govuk_test (~> 1.0)
@@ -180,8 +167,9 @@ DEPENDENCIES
   rspec-core (~> 3.9)
   rspec-expectations (~> 3.9)
   rspec-mocks (~> 3.9)
+  rubocop-govuk
   timecop
   webmock
 
 BUNDLED WITH
-   1.17.1
+   1.17.2

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,4 +1,4 @@
-desc "Run govuk-lint with similar params to CI"
+desc "Run rubocop with similar params to CI"
 task "lint" do
-  sh "govuk-lint-ruby --format clang Gemfile app bin lib spec"
+  sh "rubocop --format clang Gemfile app bin lib spec"
 end


### PR DESCRIPTION
- The GOV.UK Lint gem is deprecated in favour of using Rubocop directly
  with a set of shared configs.
- See https://github.com/alphagov/govuk-rfcs/pull/ 100 for more context.

https://trello.com/c/CdBFg6yw/1521-replace-govuk-lint-with-rubocop-govuk