### PR TITLE
Remove `lint` Rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,4 +8,4 @@ end
 
 Dir.glob('lib/tasks/*.rake').each { |r| load r }
 
-task default: %i[lint spec]
+task default: %i[spec]

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,4 +1,0 @@
-desc "Run rubocop with similar params to CI"
-task "lint" do
-  sh "rubocop --format clang Gemfile app bin lib spec"
-end


### PR DESCRIPTION
- Now we don't use `govuk-lint` to wrap RuboCop, we _could_ switch this to run `bundle exec rubocop`, but that's not very useful as it hides the directories that it operates on, and we're trying to move away from wrappers.
- Instead, I think we can leave people to run `bundle exec rubocop` on their own - it's less typing than `bundle exec rake lint` and `rubocop --help` works for options.

https://trello.com/c/IEUuFOVa/129-remove-the-lint-rake-task-from-apps-that-have-it (as part of the GOV.UK developer tools group)