### PR TITLE
Make entire repository pass Rubocop linting

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,7 @@
 require_relative "app/environment"
+require "rspec/core/rake_task"
 
-begin
-  require "rspec/core/rake_task"
-  RSpec::Core::RakeTask.new(:spec)
-rescue LoadError # rubocop:disable Lint/HandleExceptions
-end
+RSpec::Core::RakeTask.new(:spec)
 
 Dir.glob("lib/tasks/*.rake").each { |r| load r }
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,11 @@
-require_relative 'app/environment'
+require_relative "app/environment"
 
 begin
-  require 'rspec/core/rake_task'
+  require "rspec/core/rake_task"
   RSpec::Core::RakeTask.new(:spec)
 rescue LoadError # rubocop:disable Lint/HandleExceptions
 end
 
-Dir.glob('lib/tasks/*.rake').each { |r| load r }
+Dir.glob("lib/tasks/*.rake").each { |r| load r }
 
 task default: %i[spec]


### PR DESCRIPTION
This is depended on by https://github.com/alphagov/govuk-jenkinslib/pull/66.