### PR TITLE
Wrap 'require "rspec/core/rake_task"' in begin/rescue/end block

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,10 @@
 require_relative "app/environment"
-require "rspec/core/rake_task"
 
-RSpec::Core::RakeTask.new(:spec)
+begin
+  require "rspec/core/rake_task"
+  RSpec::Core::RakeTask.new(:spec)
+rescue LoadError # rubocop:disable Lint/SuppressedException
+end
 
 Dir.glob("lib/tasks/*.rake").each { |r| load r }
 


### PR DESCRIPTION
RSPec is a development dependency and as such, we see errors outside
of the dev environment if this line is not wrapped in an exception
handler.
See:
https://github.com/alphagov/cache-clearing-service/pull/259\#pullrequestreview-372584676