### PR TITLE
Extend 'default' rake task with RuboCop linting

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,4 +8,4 @@ end
 
 Dir.glob("lib/tasks/*.rake").each { |r| load r }
 
-task default: %i[spec]
+task default: %i[spec lint]

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,4 @@
+desc "Lint Ruby"
+task :lint do
+  sh "bundle exec rubocop"
+end


### PR DESCRIPTION
https://trello.com/c/5Gob6WUL/147-ensure-that-rubocop-runs-as-part-of-bundle-exec-rake-as-one-of-the-default-tasks

This adds a new 'lint' rake task that runs as part of a default call
to 'rake'. Having linting run locally by default makes it easier to
catch build issues, and is a prerequisite for moving to GitHub Actions,
since we want to avoid listing lots of separate build steps.

The 'lint' task runs RuboCop as a separate process, which is a technique
to avoid a LoadError when the gem is unavailable in production.