### PR TITLE
Update to Ruby 2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,19 +1,20 @@
 source "http://rubygems.org"
 
-gem "aws-sdk-ec2", "~> 1"
+gem "aws-sdk-ec2"
 gem "foreman"
-gem "govuk_app_config", "~> 2.3"
-gem "govuk_message_queue_consumer", "~> 3.5"
-gem "plek", "~> 4.0"
-gem "rake", "~> 13.0"
+gem "govuk_app_config"
+gem "govuk_message_queue_consumer"
+gem "plek"
+gem "rake"
+gem "thwait"
 
 group :development, :test do
   gem "byebug"
-  gem "govuk_test", "~> 1.0"
-  gem "pry", "~> 0.13"
-  gem "rspec-core", "~> 3.9"
-  gem "rspec-expectations", "~> 3.9"
-  gem "rspec-mocks", "~> 3.9"
+  gem "govuk_test"
+  gem "pry"
+  gem "rspec-core"
+  gem "rspec-expectations"
+  gem "rspec-mocks"
   gem "rubocop-govuk"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
+    e2mmap (0.1.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     foreman (0.87.1)
@@ -139,6 +140,8 @@ GEM
       faraday (>= 1.0)
     statsd-ruby (1.4.0)
     thread_safe (0.3.6)
+    thwait (0.2.0)
+      e2mmap
     timecop (0.9.1)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
@@ -162,22 +165,24 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aws-sdk-ec2 (~> 1)
+  aws-sdk-ec2
   byebug
   climate_control
   foreman
-  govuk_app_config (~> 2.3)
-  govuk_message_queue_consumer (~> 3.5)
-  govuk_test (~> 1.0)
-  plek (~> 4.0)
-  pry (~> 0.13)
-  rake (~> 13.0)
-  rspec-core (~> 3.9)
-  rspec-expectations (~> 3.9)
-  rspec-mocks (~> 3.9)
+  govuk_app_config
+  govuk_message_queue_consumer
+  govuk_test
+  plek
+  pry
+  rake
+  rspec-core
+  rspec-expectations
+  rspec-mocks
   rubocop-govuk
+  thwait
   timecop
   webmock
 
 BUNDLED WITH
-   1.17.2
+   1.17.3
+   


### PR DESCRIPTION
These are the necessary changes for Ruby 2.7, tested against 2.7.1

Since there is an automated process for updating Ruby versions in govuk apps, I changed the version locally, made the necessary updates, but raised a PR with version 2.6.6. The tests will fail on Jenkins because of this.

The only significant change that has been made other than unpinning dependencies is to add the Thwait gem as this is no longer bundled after Ruby 2.7.0.