### PR TITLE
Remove redundant Jenkinsfile config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,5 +3,5 @@
 library("govuk")
 
 node {
-  govuk.buildProject(rubyLintDiff: false)
+  govuk.buildProject()
 }


### PR DESCRIPTION
The RubyLintDiff argument has been removed.