### PR TITLE
Clear the cache both with and without a GOV.UK account session

### DIFF
--- a/app/services/fastly_clearer.rb
+++ b/app/services/fastly_clearer.rb
@@ -6,7 +6,9 @@ class FastlyClearer
 
   def clear_for(base_path_or_url)
     GovukStatsd.time("purge.fastly") do
-      purger.purge(full_url(base_path_or_url))
+      url = full_url(base_path_or_url)
+      purger.purge(url)
+      purger.purge(url, { "Cookie" => "__Host-govuk_account_session=1" })
     end
   rescue Purger::PurgeFailed => e
     raise FastlyCacheClearFailed, e

--- a/app/services/purger.rb
+++ b/app/services/purger.rb
@@ -3,12 +3,16 @@ class Purger
     @logger = logger
   end
 
-  def purge(url)
-    logger.info("Purging: #{url}")
+  def purge(url, extra_headers = {})
+    if extra_headers.empty?
+      logger.info("Purging: #{url}")
+    else
+      logger.info("Purging: #{url} #{extra_headers}")
+    end
 
     uri = URI(url)
     Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https") do |http|
-      response = http.request(PurgeRequest.new(uri.request_uri))
+      response = http.request(PurgeRequest.new(uri.request_uri, extra_headers))
       status = response.code.to_i
 
       unless (200...299).cover?(status)

--- a/app/services/varnish_clearer.rb
+++ b/app/services/varnish_clearer.rb
@@ -7,7 +7,9 @@ class VarnishClearer
   def clear_for(base_path)
     GovukStatsd.time("purge.varnish") do
       GovukNodes.of_class("cache").each do |cache_hostname|
-        purger.purge("http://#{cache_hostname}:7999#{base_path}")
+        url = "http://#{cache_hostname}:7999#{base_path}"
+        purger.purge(url)
+        purger.purge(url, { "GOVUK-Account-Session-Exists" => "1" })
       rescue Purger::PurgeFailed => e
         raise VarnishCacheClearFailed, e
       end

--- a/spec/fastly_clearer_spec.rb
+++ b/spec/fastly_clearer_spec.rb
@@ -4,9 +4,10 @@ RSpec.describe FastlyClearer do
 
   subject { described_class.new(Logger.new("/dev/null"), mock_purger) }
 
-  it "purges the Fastly cache for the base path in the payload" do
+  it "purges the Fastly cache for the base path in the payload, both with and without a GOV.UK account session cookie" do
     url = "https://www.test.gov.uk#{base_path}"
     expect(mock_purger).to receive(:purge).with(url)
+    expect(mock_purger).to receive(:purge).with(url, { "Cookie" => "__Host-govuk_account_session=1" })
 
     subject.clear_for(base_path)
   end
@@ -27,6 +28,7 @@ RSpec.describe FastlyClearer do
     it "clears the full URL rather than prepending the website root" do
       url = "https://assets.example.gov.uk#{base_path}"
       expect(mock_purger).to receive(:purge).with(url)
+      expect(mock_purger).to receive(:purge).with(url, { "Cookie" => "__Host-govuk_account_session=1" })
       subject.clear_for(url)
     end
   end

--- a/spec/varnish_clearer_spec.rb
+++ b/spec/varnish_clearer_spec.rb
@@ -9,10 +9,11 @@ RSpec.describe VarnishClearer do
     allow(GovukNodes).to receive(:of_class).with("cache").and_return(cache_hosts)
   end
 
-  it "purges the Varnish cache for the base path in the payload" do
+  it "purges the Varnish cache for the base path in the payload, both with and without a GOV.UK account session" do
     cache_hosts.each do |cache_host|
       url = "http://#{cache_host}:7999#{base_path}"
       expect(mock_purger).to receive(:purge).with(url)
+      expect(mock_purger).to receive(:purge).with(url, { "GOVUK-Account-Session-Exists" => "1" })
     end
 
     subject.clear_for(base_path)


### PR DESCRIPTION
We've decided to implement account navigation on GOV.UK by
implementing a custom request header, which is set by Fastly if a
session cookie is present (and unset otherwise).  See [1].

So, since every page will potentially have two variants cached (when
we implement the new navigation), we will need the
cache-clearing-service to handle both of them.

For Fastly, set a session cookie; the `vcl_recv` method will then
produce the `GOVUK-Account-Session-Exists` header which the caching
uses.  For Varnish, set the `GOVUK-Account-Session-Exists` header
directly, as that assumes the request has come via Fastly.

I also changed the logger to print out the extra headers, if set, so
we'll see log entries like:

    Purging: https://www.gov.uk
    Purging: https://www.gov.uk {"Cookie"=>"__Host-govuk-account-session=1"}

[1] https://github.com/alphagov/govuk-cdn-config/pull/356

---

[Trello card](https://trello.com/c/4wd8du6X/987-implement-navigation-caching-behaviour)

