### PR TITLE
Remove `expect_any_instance_of`in tests

### DIFF
--- a/app/services/fastly_clearer.rb
+++ b/app/services/fastly_clearer.rb
@@ -1,7 +1,7 @@
 class FastlyClearer
-  def initialize(logger)
+  def initialize(logger, purger = nil)
     @logger = logger
-    @purger = Purger.new(logger)
+    @purger = purger || Purger.new(logger)
   end
 
   def clear_for(base_path_or_url)

--- a/app/services/varnish_clearer.rb
+++ b/app/services/varnish_clearer.rb
@@ -1,7 +1,7 @@
 class VarnishClearer
-  def initialize(logger)
+  def initialize(logger, purger = nil)
     @logger = logger
-    @purger = Purger.new(logger)
+    @purger = purger || Purger.new(logger)
   end
 
   def clear_for(base_path)

--- a/spec/fastly_clearer_spec.rb
+++ b/spec/fastly_clearer_spec.rb
@@ -1,18 +1,19 @@
 RSpec.describe FastlyClearer do
   let(:base_path) { "/government/news/govuk-implements-new-cache-clearing" }
+  let(:mock_purger) { double(Purger) }
 
-  subject { described_class.new(Logger.new("/dev/null")) }
+  subject { described_class.new(Logger.new("/dev/null"), mock_purger) }
 
   it "purges the Fastly cache for the base path in the payload" do
     url = "https://www.test.gov.uk#{base_path}"
-    expect_any_instance_of(Purger).to receive(:purge).with(url)
+    expect(mock_purger).to receive(:purge).with(url)
 
     subject.clear_for(base_path)
   end
 
   context "if the Fastly cache clear fails" do
     before do
-      expect_any_instance_of(Purger).to receive(:purge).and_raise(Purger::PurgeFailed.new)
+      expect(mock_purger).to receive(:purge).and_raise(Purger::PurgeFailed.new)
     end
 
     it "raises an error" do
@@ -25,7 +26,7 @@ RSpec.describe FastlyClearer do
   context "if a full URL is provided" do
     it "clears the full URL rather than prepending the website root" do
       url = "https://assets.example.gov.uk#{base_path}"
-      expect_any_instance_of(Purger).to receive(:purge).with(url)
+      expect(mock_purger).to receive(:purge).with(url)
       subject.clear_for(url)
     end
   end

--- a/spec/varnish_clearer_spec.rb
+++ b/spec/varnish_clearer_spec.rb
@@ -1,8 +1,9 @@
 RSpec.describe VarnishClearer do
   let(:base_path) { "/government/news/govuk-implements-new-cache-clearing" }
   let(:cache_hosts) { %w[cache-1 cache-2] }
+  let(:mock_purger) { double(Purger) }
 
-  subject { described_class.new(Logger.new("/dev/null")) }
+  subject { described_class.new(Logger.new("/dev/null"), mock_purger) }
 
   before do
     allow(GovukNodes).to receive(:of_class).with("cache").and_return(cache_hosts)
@@ -11,7 +12,7 @@ RSpec.describe VarnishClearer do
   it "purges the Varnish cache for the base path in the payload" do
     cache_hosts.each do |cache_host|
       url = "http://#{cache_host}:7999#{base_path}"
-      expect_any_instance_of(Purger).to receive(:purge).with(url)
+      expect(mock_purger).to receive(:purge).with(url)
     end
 
     subject.clear_for(base_path)
@@ -19,7 +20,7 @@ RSpec.describe VarnishClearer do
 
   context "if the Varnish cache clear fails" do
     before do
-      expect_any_instance_of(Purger).to receive(:purge).and_raise(Purger::PurgeFailed.new)
+      allow(mock_purger).to receive(:purge).and_raise(Purger::PurgeFailed.new)
     end
 
     it "raises an error" do


### PR DESCRIPTION
The tests `fastly_clearer_spec.rb` and `varnish_clearer_spec.rb` were
using `expect_any_instance_of` to set expectations on private instance
variables. This is generally considered bad practice
(see https://github.com/rubocop/rspec-style-guide#any_instance_of).

This PR instead uses dependency injection to pass in a mock object,
 and replaces an instance of `expect` in a `before` hook with
the functionally equivalent but more semantically correct `allow`.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

