### PR TITLE
Remove allow list from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,17 +4,3 @@ updates:
     directory: /
     schedule:
       interval: daily
-    allow:
-      # Security updates
-      - dependency-name: brakeman
-        dependency-type: direct
-      # Internal gems
-      - dependency-name: "govuk*"
-        dependency-type: direct
-      - dependency-name: plek
-        dependency-type: direct
-      - dependency-name: rubocop-govuk
-        dependency-type: direct
-      # Framework gems
-      - dependency-name: rspec-core
-        dependency-type: direct


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Trello card: https://trello.com/c/DuA0q9Ck/2966-remove-allow-lists-from-dependabot-configs-2