### PR TITLE
Use TLS when fetching gem dependencies.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gem "aws-sdk-ec2"
 gem "foreman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     actionpack (7.0.3.1)
       actionview (= 7.0.3.1)


### PR DESCRIPTION
This has been the default for new Gemfiles since a major security incident at rubygems.org in 2013[[1]].

[1]: https://venturebeat.com/business/rubygems-org-hacked-interrupting-heroku-services-and-putting-millions-of-sites-using-rails-at-risk/