### PR TITLE
Add Dockerfile for container image build.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.dockerignore
+.git
+.gitignore
+Dockerfile
+Jenkinsfile
+Procfile
+README.md
+coverage
+docs
+features
+log
+node_modules
+spec
+test
+tmp
+uploads
+vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ COPY . ./
 FROM $base_image
 
 ENV GOVUK_APP_NAME=cache-clearing-service
+ENV GOVUK_ENV=deployment
 
 WORKDIR $APP_HOME
 COPY --from=builder $BUNDLE_PATH/ $BUNDLE_PATH/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:3.1.2
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:3.1.2
+
+FROM $builder_image AS builder
+
+WORKDIR $APP_HOME
+COPY Gemfile Gemfile.lock .ruby-version ./
+RUN bundle install
+COPY . ./
+
+
+FROM $base_image
+
+ENV GOVUK_APP_NAME=cache-clearing-service
+
+WORKDIR $APP_HOME
+COPY --from=builder $BUNDLE_PATH/ $BUNDLE_PATH/
+COPY --from=builder $APP_HOME ./
+ENTRYPOINT ["rake", "message_queue:consumer"]
+CMD ["QUEUE=high"]

--- a/app/config.rb
+++ b/app/config.rb
@@ -12,31 +12,16 @@ class Config
   end
 
   def logger
-    @logger ||= begin
-      logfile = File.open(log_path, "a")
-      logfile.sync = true
-
-      Logger.new(MultiIO.new($stdout, logfile), "daily")
-    end
+    @logger ||= Logger.new(log_file)
   end
 
 private
 
-  def log_path
-    File.join(app_root, "log", "#{environment}.log")
-  end
-
-  class MultiIO
-    def initialize(*targets)
-      @targets = targets
-    end
-
-    def write(*args)
-      @targets.each { |t| t.write(*args) }
-    end
-
-    def close
-      @targets.each(&:close)
+  def log_file
+    if ENV["RAILS_LOG_TO_STDOUT"]
+      $stdout
+    else
+      File.open(File.join(app_root, "log", "#{environment}.log"), "a")
     end
   end
 end


### PR DESCRIPTION
Also fix logging so that the app can run in a container without trying to create files under its own source directory.

Tested: successfully built locally (`docker build -t cache-clearing-service .`) and [on GitHub Actions](https://github.com/alphagov/cache-clearing-service/actions/runs/3686440067).