### PR TITLE
Remove use AWS_STACKNAME env var

### DIFF
--- a/lib/govuk_nodes/aws_fetcher.rb
+++ b/lib/govuk_nodes/aws_fetcher.rb
@@ -10,10 +10,6 @@ class GovukNodes
       @ec2 ||= Aws::EC2::Client.new
     end
 
-    def stack_name
-      @stack_name ||= ENV["AWS_STACKNAME"]
-    end
-
     def filter(name, value)
       { name:, values: [value] }
     end
@@ -21,7 +17,6 @@ class GovukNodes
     def instances_of_class(node_class)
       ec2.describe_instances(
         filters: [
-          filter("tag:aws_stackname", stack_name),
           filter("tag:aws_migration", node_class.tr("-", "_")),
           filter("instance-state-name", "running"),
         ],

--- a/spec/govuk_nodes/aws_fetcher_spec.rb
+++ b/spec/govuk_nodes/aws_fetcher_spec.rb
@@ -4,7 +4,6 @@ require "govuk_nodes/aws_fetcher"
 
 RSpec.describe GovukNodes::AWSFetcher do
   let(:node_class) { "email_alert_api" }
-  let(:stack_name) { "green" }
 
   let!(:aws_client) do
     Aws::EC2::Client.new(stub_responses: {
@@ -27,17 +26,10 @@ RSpec.describe GovukNodes::AWSFetcher do
     allow(Aws::EC2::Client).to receive(:new).and_return(aws_client)
   end
 
-  around do |example|
-    ClimateControl.modify AWS_STACKNAME: stack_name do
-      example.run
-    end
-  end
-
   describe "#hostnames_of_class(node_class)" do
     it "queries AWS for the nodes" do
       expect(aws_client).to receive(:describe_instances).with(
         filters: [
-          { name: "tag:aws_stackname", values: [stack_name] },
           { name: "tag:aws_migration", values: [node_class] },
           { name: "instance-state-name", values: %w[running] },
         ],

--- a/spec/govuk_nodes_spec.rb
+++ b/spec/govuk_nodes_spec.rb
@@ -4,15 +4,8 @@ require "govuk_nodes"
 
 RSpec.describe GovukNodes do
   let(:node_class) { "email_alert_api" }
-  let(:stack_name) { "green" }
 
   context "if the AWS flag is on" do
-    around do |example|
-      ClimateControl.modify AWS_STACKNAME: stack_name do
-        example.run
-      end
-    end
-
     let(:fetcher_response) do
       %w[
         email_alert_api-1


### PR DESCRIPTION
This is env is un-needed as we no longer need to distigush between AWS and Carrenza (we don't use Carrenza anymore). We also don't need to filter EC2 instances by stackname, we never implemented blue/green deployments (and have no plans too). Our current instances all have the same stackname "blue".


