### PR TITLE
Add retirement notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Cache Clearing Service
 
+> **Cache Clearing Service is retired**
+
 A message queue consumer application which clears the Fastly CDN cache when new content is published. Messages are read from the `published_documents` exchange which carries documents published from all publishing applications.
 
 ## Technical documentation


### PR DESCRIPTION
## Context

Cache Clearing Service was build in August 2018. At the time GOV.UK pages would typically return 30 minute cached version of a page, which was an unacceptably long delay for publishers. The service listens for publishing events and purges the registered routes from the Varnish and Fastly caches. This purging however doesn’t remove all variants of the content and thus cannot be relied upon for all circumstances. Consequently:
- any pages that are accessed with query strings or are within prefix routes won’t be purged from the cache by Cache Clearing Service.
- users could experience inconsistent experiences where one user can see a changed page and the other not
- GOV.UK HTTP responses incorrectly tell a client they can cache a page for the cache period when this isn’t strictly true

Content folks have been notified in [#govuk-2ndline-content](https://gds.slack.com/archives/CMW1476KZ/p1688395861315089) and [#content-community](https://gds.slack.com/archives/CACV3TACU/p1688398664580089)

## Why

Currently, the cache period significantly reduced to 5 minutes. [Purging a page from cache](https://docs.publishing.service.gov.uk/manual/purge-cache) is documented in the dev docs.

For those reasons the service is deemed as redundant. Removing it will reduce maintenance burden for developers and reduce cost of hosting the service.

[GIFT week summer 2023 card](https://trello.com/c/ENPwB2vT/41-retire-cache-clearing-service)
[Tech debt card](https://trello.com/c/TX9wLihh/101-cache-clearing-app-exists-and-we-dont-think-its-necessary-replacing-cache-clearing-app-only-clears-path-not-query-strings)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

